### PR TITLE
feat: Add Sparklines to Message Log

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,10 +2,11 @@ import "@mantine/core/styles.css";
 import { MantineProvider } from "@mantine/core";
 import { MidiContextProvider } from "./contexts/MidiContextProvider";
 import { JunoProgrammer } from "./components/JunoProgrammer";
+import { mantineTheme } from "./mantineTheme";
 
 function App() {
   return (
-    <MantineProvider defaultColorScheme="dark">
+    <MantineProvider theme={mantineTheme} defaultColorScheme="dark">
       <MidiContextProvider>
         <JunoProgrammer />
       </MidiContextProvider>

--- a/src/components/ConfigPanel.tsx
+++ b/src/components/ConfigPanel.tsx
@@ -9,6 +9,7 @@ import {
   IconBrain,
 } from "@tabler/icons-react";
 import { useConfigStore } from "../stores/configStore";
+import { kiwiTechnicsSysexId } from "../utils/sysexUtils";
 
 export const ConfigPanel = () => {
   const midiContext = useMidiContext();
@@ -27,8 +28,7 @@ export const ConfigPanel = () => {
     }
   };
 
-  const sendProgramChangeSysex = () => {
-    console.log("Send sysex message");
+  const sendDeviceEnquirySysex = () => {
     if (!configStore.output?.id) {
       console.log("Send sysex message: no output");
       return;
@@ -49,6 +49,42 @@ export const ConfigPanel = () => {
     ];
 
     output.sendSysex(universalNonRealtimeIdentification, universalData);
+  };
+
+  const requestGlobalDumpSysex = () => {
+    if (!configStore.output?.id) {
+      console.log("Send sysex message: no output");
+      return;
+    }
+
+    const output = WebMidi.getOutputById(configStore.output?.id);
+    if (!output) {
+      console.log("Send sysex message: no output");
+      return;
+    }
+
+    const additionalKiwiIdentifiers = [0x60, 0x03, 0x00]
+    const requestGlobalDump = 0x01
+
+    output.sendSysex(kiwiTechnicsSysexId, [...additionalKiwiIdentifiers, requestGlobalDump])
+  };
+
+  const requestPatchDumpSysex = () => {
+    if (!configStore.output?.id) {
+      console.log("Send sysex message: no output");
+      return;
+    }
+
+    const output = WebMidi.getOutputById(configStore.output?.id);
+    if (!output) {
+      console.log("Send sysex message: no output");
+      return;
+    }
+
+    const additionalKiwiIdentifiers = [0x60, 0x03, 0x00]
+    const requestPatchDump = 0x03
+
+    output.sendSysex(kiwiTechnicsSysexId, [...additionalKiwiIdentifiers, requestPatchDump])
   };
 
   return (
@@ -113,8 +149,14 @@ export const ConfigPanel = () => {
         <Button onClick={midiPanic} leftSection={<IconExclamationCircle />}>
           Panic
         </Button>
-        <Button onClick={sendProgramChangeSysex} leftSection={<IconBrain />}>
-          Sysex
+        <Button onClick={sendDeviceEnquirySysex} leftSection={<IconBrain />}>
+          Device Enquiry
+        </Button>
+        <Button onClick={requestGlobalDumpSysex} leftSection={<IconBrain />}>
+          Request Global Dump
+        </Button>
+        <Button onClick={requestPatchDumpSysex} leftSection={<IconBrain />}>
+          Request Patch Dump
         </Button>
       </Stack>
     </Group>

--- a/src/components/DataSparkline.tsx
+++ b/src/components/DataSparkline.tsx
@@ -1,0 +1,61 @@
+interface DataSparklineParams {
+  data: number[]
+}
+
+export const DataSparkline = ({ data }: DataSparklineParams) => {
+  const bytesPerRow = 64
+  const cellSize = 10
+
+  const width = bytesPerRow * cellSize;
+  const height = Math.ceil(data.length / bytesPerRow) * cellSize;
+
+  
+  return <svg width={width} height={height}>
+    {data.map((d, i) => {
+      const x = (i % bytesPerRow) * cellSize;
+      const y = Math.floor(i / bytesPerRow) * cellSize;
+
+      return (
+        <rect
+          key={`sparkline-${i}`}
+          x={x}
+          y={y}
+          width={cellSize}
+          height={cellSize}
+          fill={`#${mapColor(d)}`}
+        />
+      )
+    })}
+  </svg>
+}
+
+function mapColor(byte: number) {
+  // Convert byte to HSL (hue, saturation, lightness)
+  const hue = Math.floor((byte / 255) * 360); // 0-360 degrees around color wheel
+  const saturation = 100; // Full saturation
+  const lightness = 50; // Medium lightness
+  
+  // Convert HSL to RGB
+  const c = (1 - Math.abs(2 * lightness / 100 - 1)) * saturation / 100;
+  const x = c * (1 - Math.abs((hue / 60) % 2 - 1));
+  const m = lightness / 100 - c / 2;
+  
+  let r, g, b;
+  if (hue < 60) {
+    [r, g, b] = [c, x, 0];
+  } else if (hue < 120) {
+    [r, g, b] = [x, c, 0];
+  } else if (hue < 180) {
+    [r, g, b] = [0, c, x];
+  } else if (hue < 240) {
+    [r, g, b] = [0, x, c];
+  } else if (hue < 300) {
+    [r, g, b] = [x, 0, c];
+  } else {
+    [r, g, b] = [c, 0, x];
+  }
+  
+  // Convert RGB to hex
+  const toHex = (v: number) => Math.round((v + m) * 255).toString(16).padStart(2, '0');
+  return `${toHex(r)}${toHex(g)}${toHex(b)}`;
+};

--- a/src/contexts/MidiContext.tsx
+++ b/src/contexts/MidiContext.tsx
@@ -1,7 +1,5 @@
 import { createContext } from "react";
 
-export type MidiChannel = number;
-
 export interface MidiPortData {
   id: string;
   name: string | null;

--- a/src/mantineTheme.ts
+++ b/src/mantineTheme.ts
@@ -1,0 +1,5 @@
+import { createTheme } from '@mantine/core';
+
+export const mantineTheme = createTheme({
+  
+});

--- a/src/types/Midi.ts
+++ b/src/types/Midi.ts
@@ -3,7 +3,8 @@
 import { IntRange } from "./IntRange";
 
 export type MidiMessageType = "noteon" | "noteoff" | "controlchange" | "programchange" | "pitchbend" | "sysex" | "channelaftertouch" | "keyaftertouch";
-export type MidiCcValue = IntRange<0, 127>
+export type MidiCcValue = IntRange<0, 128>
+export type MidiChannel = IntRange<0, 16>
 
 export const isMidiMessageType = (messageType: string): messageType is MidiMessageType => {
   const messageTypes = new Set(["noteon", "noteoff", "controlchange", "programchange", "pitchbend", "sysex"])

--- a/src/utils/sysexUtils.ts
+++ b/src/utils/sysexUtils.ts
@@ -1,8 +1,5 @@
+import _ from "lodash";
 import { Message } from "webmidi";
-
-// Kiwitechnics
-// Kiwitechnics manufacturer ID, per https://midi.org/sysexidtable
-export const kiwiTechnicsSysexId = [0x00, 0x21, 0x16];
 
 export const isSysexDeviceEnquiryReply = (message: Message) => {
   if (!message.isSystemMessage) {
@@ -10,4 +7,23 @@ export const isSysexDeviceEnquiryReply = (message: Message) => {
   }
   
   return message.data[3] === 0x06 && message.data[4] === 0x02
+}
+
+// Kiwitechnics
+// Kiwitechnics manufacturer ID, per https://midi.org/sysexidtable
+export const kiwiTechnicsSysexId = [0x00, 0x21, 0x16];
+const kiwi106Identifier = [0x60, 0x03];
+export const isKiwiTechnicsSysexMessage = (message: Message) => {
+  const manufacturerId = message.data.slice(1, 4)
+  return _.isEqual(manufacturerId, kiwiTechnicsSysexId)
+}
+
+export const isKiwi106SysexMessage = (message: Message) => {
+  // message.data[6] contains device ID, but I don't think we care?
+  return isKiwiTechnicsSysexMessage(message) && 
+    _.isEqual(message.data.slice(4, 6), kiwi106Identifier)
+}
+
+export const isKiwi106GlobalDumpSysexMessage = (message: Message) => {
+  return isKiwi106SysexMessage(message) && message.data[7] === 0x02;
 }

--- a/src/utils/trimMidiCcValue.ts
+++ b/src/utils/trimMidiCcValue.ts
@@ -1,4 +1,8 @@
-import { MidiCcValue } from "../types/Midi";
+import { MidiCcValue, MidiChannel } from "../types/Midi";
+
+export const trimMidiChannel: (n: number) => MidiChannel = (v) => {
+  return Math.min(15, Math.max(0, v)) as MidiChannel;
+}
 
 export const trimMidiCcValue: (n: number) => MidiCcValue = (v) => {
   return Math.min(127, Math.max(0, v)) as MidiCcValue;


### PR DESCRIPTION
# Problem
We want to visualize incoming MIDI messages so we can better reason with complex messages like sysex

# Solution
Add a ["sparkline"](https://en.wikipedia.org/wiki/Sparkline) to each message; simply a short visualization of the incoming MIDI data.

# How to Verify
- Check out `feat/update-theme`
- Run the app connected to your synthesizer
- Send some midi messages from your synth
- See the sparklines appear!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Applied a custom theme for a refreshed and consistent app appearance.
  - Updated the device configuration panel with new interactive controls for advanced MIDI inquiries and data dumps.
  - Introduced a data visualization component that renders real-time sparkline displays of MIDI data.
  - Enhanced the presentation of MIDI messages with improved formatting and visual cues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->